### PR TITLE
Debug build for #42

### DIFF
--- a/internal/miner/client.go
+++ b/internal/miner/client.go
@@ -183,6 +183,7 @@ func (t *TcpClient) ping(manComms *managerComms) {
 			connected = false
 		case <-time.After(5 * time.Second):
 			t.SendChan <- fmt.Sprintf("PING %d", hashRate/1000)
+			t.comms.ClearHashRate <- struct{}{}
 		}
 	}
 	close(manComms.pingStopped)

--- a/internal/miner/comms.go
+++ b/internal/miner/comms.go
@@ -19,6 +19,7 @@ func NewComms() *Comms {
 		Reports:           make(chan Report, 0),
 		Solutions:         make(chan Solution, 0),
 		Joined:            make(chan struct{}, 0),
+		ClearHashRate:     make(chan struct{}, 0),
 	}
 }
 
@@ -38,6 +39,7 @@ type Comms struct {
 	Reports           chan Report
 	Solutions         chan Solution
 	Joined            chan struct{}
+	ClearHashRate     chan struct{}
 }
 
 type Report struct {

--- a/internal/miner/mine.go
+++ b/internal/miner/mine.go
@@ -149,6 +149,8 @@ func Mine(opts *Opts) {
 			}
 			totalHashes += report.Hashes
 			comms.HashRate <- hashRate
+		case <-comms.ClearHashRate:
+			workerReports = make(map[string]Report)
 		case resp = <-client.RecvChan:
 			go Parse(comms, opts.IpAddr, opts.Wallet, targetBlock, resp)
 		}


### PR DESCRIPTION
 - This commit forces the mining manager to clear the hash rate map
   after each PING is sent
 - If the working theory of hung/dead goroutines is correct, the
   reported hash rate should decrease over time